### PR TITLE
Adding WildMenu colors

### DIFF
--- a/colors/github.vim
+++ b/colors/github.vim
@@ -4,7 +4,7 @@
 " URL: https://github.com/albertorestifo/github.vim
 " Author: Alberto Restifo &lt;alberto@hike.ninja&gt;
 " License: MIT
-" Last Change: 2016/11/28 06:42
+" Last Change: 2017/02/16 12:06
 " ===============================================================
 
 let g:colors_name="github"
@@ -52,6 +52,7 @@ hi TabLineSel guifg=#333333 ctermfg=236 guibg=#ffffff ctermbg=15 gui=NONE cterm=
 hi Title guifg=#333333 ctermfg=236 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi Visual guibg=#c8c8fa ctermbg=189 gui=NONE cterm=NONE
 hi WarningMsg guifg=#ed6a43 ctermfg=203 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi WildMenu guifg=#464a4d ctermfg=239 guibg=#e0e0e0 ctermbg=254 gui=NONE cterm=NONE
 hi Comment guifg=#969896 ctermfg=246 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi Constant guifg=#0086b3 ctermfg=31 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi String guifg=#183691 ctermfg=24 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE


### PR DESCRIPTION
The colorscheme missed WildMenu colors which looked not Github-Like when using `set wildmenu`. These commit changes the colors to the same as StatusLineNC.
Before:
![screenshot from 2017-02-16 12-12-38](https://cloud.githubusercontent.com/assets/1415596/23019225/8199c754-f441-11e6-9a75-605e820d9438.png)

After:
![screenshot from 2017-02-16 12-12-05](https://cloud.githubusercontent.com/assets/1415596/23019232/86d1ab24-f441-11e6-9cc3-26d3c60e3b07.png)

